### PR TITLE
Potential fix for code scanning alert no. 2: Implicit narrowing conversion in compound assignment

### DIFF
--- a/src_test/com/serotonin/modbus4j/test/ListenerTest.java
+++ b/src_test/com/serotonin/modbus4j/test/ListenerTest.java
@@ -67,7 +67,7 @@ public class ListenerTest {
         processImage.setInput(10, !processImage.getInput(10));
         processImage.setInput(13, !processImage.getInput(13));
 
-        processImage.setNumeric(RegisterRange.INPUT_REGISTER, 20, DataType.FOUR_BYTE_FLOAT, ir1Value += 0.01);
+        processImage.setNumeric(RegisterRange.INPUT_REGISTER, 20, DataType.FOUR_BYTE_FLOAT, ir1Value += 0.01f);
 
         short hr1Value = processImage.getNumeric(RegisterRange.HOLDING_REGISTER, 80, DataType.TWO_BYTE_BCD)
                 .shortValue();


### PR DESCRIPTION
Potential fix for [https://github.com/gythialy/modbus4j/security/code-scanning/2](https://github.com/gythialy/modbus4j/security/code-scanning/2)

To fix the implicit narrowing conversion in the compound assignment, ensure both sides of the operation use the same type (`float`). The preferred way is to make the right-hand side of the operation a `float` as well. In this case, explicitly make `0.01` a float by writing `0.01f` instead of `0.01`. This avoids the implicit double-to-float conversion. 

Edit line 70 in `src_test/com/serotonin/modbus4j/test/ListenerTest.java`, replacing `ir1Value += 0.01` with `ir1Value += 0.01f`. No new imports or definitions are required; only the numeric literal needs to change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
